### PR TITLE
fix clone target path of quaternion_operation

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -1,5 +1,5 @@
 repositories:
-  quaternion_operation:
+  arav-jp/quaternion_operation:
     type: git
     url: https://github.com/arav-jp/quaternion_operation.git
     version: master


### PR DESCRIPTION
because we're using forked implementation, and this change is needed to keep consistency.